### PR TITLE
Fix crash when NPCNames is empty

### DIFF
--- a/Hephaestus/Program.cs
+++ b/Hephaestus/Program.cs
@@ -388,8 +388,16 @@ namespace Hephaestus
                         // Set the book properties
                         book.EditorID = $"{objEditorID}_{schematicType}";
                         book.Name = $"{objType} {schematicType}: {objName}";
-                        book.Description =
-                            $"A {schematicType.ToLower()} created by {NPCNames[random.Next(NPCNames.Count)]}. It details the process of {processNameCont} {aAn}{objName}.";
+                        if (NPCNames.Count > 0)
+                        {
+                            book.Description =
+                                $"A {schematicType.ToLower()} created by {NPCNames[random.Next(NPCNames.Count)]}. It details the process of {processNameCont} {aAn}{objName}.";
+                        }
+                        else
+                        {
+                            book.Description =
+                                $"A {schematicType.ToLower()}. It details the process of {processNameCont} {aAn}{objName}.";
+                        }
                         book.Value = objValue * (noteToSchematicRatio + 2);
                         book.Weight = 0.25f;
                         book.Model = GenData.bookModelLib[bookModelSetKey];

--- a/Hephaestus/Program.cs
+++ b/Hephaestus/Program.cs
@@ -381,7 +381,15 @@ namespace Hephaestus
                                 NPCNames.AddRange(GenData.OrcNPCNames);
                                 NPCNames.AddRange(GenData.DwemerNPCNames);
                             }
+                        } else {
+                            NPCNames.AddRange(GenData.NordNPCNames);
+                            NPCNames.AddRange(GenData.HumanNPCNames);
+                            NPCNames.AddRange(GenData.BeastNPCNames);
+                            NPCNames.AddRange(GenData.ElfNPCNames);
+                            NPCNames.AddRange(GenData.OrcNPCNames);
+                            NPCNames.AddRange(GenData.DwemerNPCNames);
                         }
+
                         // create a new book
                         book = state.PatchMod.Books.AddNew();
 


### PR DESCRIPTION
Fixes this crash I encountered, and apparently so did someone in your comments:
```
Assigning item types and prepping things ...
Patching for Potion of Blood ...
System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
   at System.Collections.Generic.List`1.get_Item(Int32 index)
   at Hephaestus.Program.RunPatch(IPatcherState`2 state) in F:\tmp\Synthesis\rvmcfdzj.l05\Git\fbx413i3.pfn\Runner\Hephaestus\Program.cs:line 391
   at Mutagen.Bethesda.Synthesis.SynthesisPipeline.<>c__DisplayClass15_0`2.<<AddPatch>b__0>d.MoveNext() in D:\a\Synthesis\Synthesis\Mutagen.Bethesda.Synthesis\Pipeline\SynthesisPipeline.cs:line 103
--- End of stack trace from previous location ---
   at Mutagen.Bethesda.Synthesis.SynthesisPipeline.Run(RunSynthesisMutagenPatcher args, Nullable`1 exportKey, IFileSystem fileSystem) in D:\a\Synthesis\Synthesis\Mutagen.Bethesda.Synthesis\Pipeline\SynthesisPipeline.cs:line 607
   at Mutagen.Bethesda.Synthesis.SynthesisPipeline.<>c__DisplayClass43_0.<<Run>b__0>d.MoveNext() in D:\a\Synthesis\Synthesis\Mutagen.Bethesda.Synthesis\Pipeline\SynthesisPipeline.cs:line 472
--- End of stack trace from previous location ---
   at Mutagen.Bethesda.Synthesis.SynthesisPipeline.HandleOnShutdown(Func`1 a) in D:\a\Synthesis\Synthesis\Mutagen.Bethesda.Synthesis\Pipeline\SynthesisPipeline.cs:line 833
   at Mutagen.Bethesda.Synthesis.SynthesisPipeline.Run(RunSynthesisMutagenPatcher args, IFileSystem fileSystem) in D:\a\Synthesis\Synthesis\Mutagen.Bethesda.Synthesis\Pipeline\SynthesisPipeline.cs:line 460
   at Mutagen.Bethesda.Synthesis.SynthesisPipeline.<>c__DisplayClass42_0.<<InternalRun>b__1>d.MoveNext() in D:\a\Synthesis\Synthesis\Mutagen.Bethesda.Synthesis\Pipeline\SynthesisPipeline.cs:line 432
```